### PR TITLE
Retroactive proposal for QUIC connection handling in TPU

### DIFF
--- a/agenda/agenda_5.md
+++ b/agenda/agenda_5.md
@@ -5,4 +5,4 @@ Duration: 30 minutes
 Zoom: To be shared in the #core-community-call channel on Solana Tech Discord
 Agenda
 
-- TBD
+- Retroactive proposal for QUIC connection handling in TPU


### PR DESCRIPTION
Last years changes to TPU skipped the regular proposal process It would be good to document & present:
* what are the design goals?
* how were parameters tuned (esp. wrt to recv_window)?