### PR TITLE
SIMD 0047 - Syscall last restart slot

### DIFF
--- a/agenda/agenda_5.md
+++ b/agenda/agenda_5.md
@@ -6,3 +6,4 @@ Zoom: To be shared in the #core-community-call channel on Solana Tech Discord
 Agenda
 
 - TBD
+- [SIMD-0047](https://github.com/solana-foundation/solana-improvement-documents/pull/47) Syscall to get the last restart slot


### PR DESCRIPTION
Create a new syscall which can be used to get the last restart slot (currently
the last time hard fork was done on the cluster).
