### PR TITLE
Remove STL from agenda_17

### DIFF
--- a/agenda/agenda_17.md
+++ b/agenda/agenda_17.md
@@ -6,6 +6,4 @@
 
 **Agenda**
 
-- Solana Transport Layer v1.0 
-   - The STL (Solana Transport Layer) is a partial redesign of the Solana peer-to-peer network stack from first principles, with a focus on security and high performance.
 - Please append your topics suggestions.


### PR DESCRIPTION
Firedancer does not have an STL update for this core community call. We've been focused on the existing network stack.